### PR TITLE
Fix for omniauth/oauth2 2.x

### DIFF
--- a/lib/omniauth/donorhub/version.rb
+++ b/lib/omniauth/donorhub/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Donorhub
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/donorhub.rb
+++ b/lib/omniauth/strategies/donorhub.rb
@@ -46,6 +46,14 @@ module OmniAuth
         super
       end
 
+      def token_params
+        options.token_params = options.token_params.merge({
+          client_id: options.client_id,
+          client_secret: options.client_secret,
+        })
+        super
+      end
+
       private
 
       def oauth_path


### PR DESCRIPTION
The client_id and client_secret were left out of the token request after upgrading to omniauth 2.x and oauth2 2.x. This fixes that.

Tested on MPDX staging.